### PR TITLE
修复 width 的默认值

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 > 使用此组件需要依赖小程序基础库 2.2.1 以上版本，同时依赖开发者工具的 npm 构建。具体详情可查阅[官方 npm 文档](https://developers.weixin.qq.com/miniprogram/dev/devtools/npm.html)。
 
 ## 使用效果
+
 ![slide-view](./docs/slide-view.gif)
 
 > PS：此组件默认只携带基本样式，若想要获得上图中的效果，可参考 [tools/demo](./tools/demo/pages/index/index.wxss) 中的例子实现。
@@ -26,6 +27,7 @@ npm install --save miniprogram-slide-view
   }
 }
 ```
+
 3. WXML 文件中引用 slide-view
 
 每一个 slide-view 提供两个`<slot>`节点，用于承载组件引用时提供的子节点。left 节点用于承载静止时 slide-view 所展示的节点，此节点的宽高应与传入 slide-view 的宽高相同。right 节点用于承载滑动时所展示的节点，其宽度应于传入 slide-view 的 slideWidth 相同。
@@ -42,10 +44,8 @@ npm install --save miniprogram-slide-view
 
 **slide-view的属性介绍如下：**
 
-| 属性名                   | 类型         | 默认值                    | 是否必须    | 说明                                        |
-|-------------------------|--------------|---------------------------|------------|---------------------------------------------|
-| width                   | Number       | 显示屏幕的宽度             | 是          | slide-view组件的宽度                        |
-| height                  | Number       | 0                         | 是          | slide-view组件的高度                        |
-| slide-width              | Number       | 0                         | 是          | 滑动展示区域的宽度（默认高度与slide-view相同）|
-
-
+| 属性名                   | 类型         | 单位         | 默认值                    | 是否必须    | 说明                                        |
+|-------------------------|--------------|--------------|---------------------------|------------|---------------------------------------------|
+| width                   | Number       | rpx          | 显示屏幕的宽度             | 是          | slide-view组件的宽度                        |
+| height                  | Number       | rpx          | 0                         | 是          | slide-view组件的高度                        |
+| slide-width             | Number       | rpx          | 0                         | 是          | 滑动展示区域的宽度（默认高度与slide-view相同）|

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // slide-view/slide-view.js
-const _windowWidth = wx.getSystemInfoSync().windowWidth
+const _windowWidth = wx.getSystemInfoSync().windowWidth // (px)
 Component({
   /**
    * 组件的属性列表
@@ -8,17 +8,17 @@ Component({
     multipleSlots: true,
   },
   properties: {
-    //  组件显示区域的宽度
+    //  组件显示区域的宽度 (rpx)
     width: {
       type: Number,
-      value: _windowWidth
+      value: 750 // 750rpx 即整屏宽
     },
-    //  组件显示区域的高度
+    //  组件显示区域的高度 (rpx)
     height: {
       type: Number,
       value: 0,
     },
-    //  组件滑动显示区域的宽度
+    //  组件滑动显示区域的宽度 (rpx)
     slideWidth: {
       type: Number,
       value: 0
@@ -29,7 +29,7 @@ Component({
    * 组件的初始数据
    */
   data: {
-    viewWidth: _windowWidth,
+    viewWidth: _windowWidth, // (rpx)
     //  movable-view偏移量
     x: 0,
     //  movable-view是否可以出界


### PR DESCRIPTION
`width` 变量是以 rpx 为单位的

- Before, 原来的默认值错误地设置成了 px 单位的 `_windowWidth`
- After, 现在将默认值修改为 `750` （750 rpx 即整屏宽）